### PR TITLE
fix(docker): Wrong image referenced in compose file.

### DIFF
--- a/docker-compose-v2.yml
+++ b/docker-compose-v2.yml
@@ -17,7 +17,7 @@ services:
     depends_on:
       - front
   front:
-    image: zbbfufu/sfeir-front:2018
+    image: zbbfufu/docker-sfeir-front:2.0
     build: ./front
     ports:
       - "80:3000"
@@ -26,7 +26,7 @@ services:
     depends_on:
       - back
   back:
-    image: zbbfufu/sfeir-back:2018
+    image: zbbfufu/docker-sfeir-back:2.0
     build: ./back
     networks:
       - web_net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       depends_on:
         - front
   front:
-    image: zbbfufu/sfeir-front:2018
+    image: zbbfufu/docker-sfeir-front:2.0
     build: ./front
     ports:
         - "80:3000"
@@ -28,7 +28,7 @@ services:
     deploy:
        replicas: 25
   back:
-    image: zbbfufu/sfeir-back:2018
+    image: zbbfufu/docker-sfeir-back:2.0
     build: ./back
     networks:
       - web_net


### PR DESCRIPTION
You can check the image name right here: https://hub.docker.com/u/zbbfufu/

I modified the compose file V3 for Swarm, because it doesn't support images that aren't pre-build. (so if it doesn't find it local, it pulls it on the Docker store)

I modified the compose file V2 to stay consistent with the V3 version even though it works perfectly fine.